### PR TITLE
closes #6 fix interesting header

### DIFF
--- a/HeadersAnalyzer.py
+++ b/HeadersAnalyzer.py
@@ -456,6 +456,12 @@ class BurpExtender(IBurpExtender, IScannerCheck, ITab, IExtensionStateListener):
         for i in range(0, model.getSize()):
             list_boring_headers.append(model.getElementAt(i))
         
+        if self.xPermittedCrossDomainPoliciesCB.isSelected():
+            list_boring_headers.append('x-permitted-cross-domain-policies')
+
+        if self.contentSecurityPolicyCB.isSelected():
+            list_boring_headers.append('content-security-policy')
+
         issuename = "Interesting Header(s)"
         issuelevel = "Low"
         issuedetail = "<p>The response includes the following potentially interesting headers:</p><ul>"


### PR DESCRIPTION
When the security header checkbox for "x-permitted-cross-domain-policies" is enabled during the scan, this header is already getting validated and so it should not show up in the list of boring/interesting headers in the issue list and report.

The same applies to 'content-security-policy' header as well.